### PR TITLE
Adds schema configuration reading

### DIFF
--- a/db.go
+++ b/db.go
@@ -54,6 +54,7 @@ func getDBInfoFromINIConfig(cfg *ini.File, connection string) *dbInfo {
 			File:       dbCfgModel.Key("file").Value(),
 			Password:   dbCfgModel.Key("password").Value(),
 			Database:   dbCfgModel.Key("database").Value(),
+			Schema:     dbCfgModel.Key("schema").Value(),
 		}
 	}
 


### PR DESCRIPTION
Needed to set the schema for postgresql connections, when defined in the adm.ini config file it shouldn't ask again the developer for it.